### PR TITLE
feat: add survey report interactive questions

### DIFF
--- a/surveyreport/hooks.py
+++ b/surveyreport/hooks.py
@@ -3,37 +3,29 @@ from tutor import hooks, config as tutor_config, fmt
 import click
 from tutor.interactive import ask_bool
 
-
-@hooks.Actions.INTERACTIVE_CONFIGURATION.add()
+@hooks.Actions.CONFIG_INTERACTIVE.add()
 def ask_survey_report_questions(config: Config) -> None:
+    fmt.echo_info(
+    """The Open edX Project relies on the collective strength of its community to be a thriving platform for online education"""
+    )
+    fmt.echo_info(
+    """We invite you to join the Open edX Data Sharing Initiative by sharing an anonymized reports of aggregated data from your institution's usage of the platform."""
+    )
+    fmt.echo_info(
+    """The report data will be sent to Axim Collaborative, the non-profit behind the Open edX project."""
+    )
+
+    texto_con_enlace = click.style("See more: https://github.com/eduNEXT/edx-platform/tree/master/openedx/features/survey_report#survey-report", fg='blue', underline=True)
+    click.echo(texto_con_enlace)
+
     defaults = tutor_config.get_defaults()
     enable_survey_report = click.confirm(
         fmt.question(
-            "Would you like to send reports of usage back to the Open edX project?"
+            "Would you like to send automatic and anonymized reports of usage back to the Open edX project?"
             " Type 'n' if you don't want to"
         ),
         prompt_suffix=" ",
         default=True,
     )
     config["SURVEYREPORT_ENABLE"] = enable_survey_report
-
-    if enable_survey_report:
-        ask_bool(
-            (
-                "Send anonymous survey report? Important note:"
-                " the report will be sent with a unique id instead of site name."
-            ),
-            "SURVEYREPORT_ANONYMOUS",
-            config,
-            defaults,
-        )
-        ask_bool(
-            (
-                "Send survey report automatically? Important note:"
-                " If you don't want to send it automatically, you must send it from Django admin."
-            ),
-            "SURVEYREPORT_AUTO_SEND",
-            config,
-            defaults,
-        )
-        
+    config["SURVEYREPORT_AUTO_SEND"] = enable_survey_report

--- a/surveyreport/hooks.py
+++ b/surveyreport/hooks.py
@@ -1,0 +1,39 @@
+from tutor.types import Config, get_typed
+from tutor import hooks, config as tutor_config, fmt
+import click
+from tutor.interactive import ask_bool
+
+
+@hooks.Actions.INTERACTIVE_CONFIGURATION.add()
+def ask_survey_report_questions(config: Config) -> None:
+    defaults = tutor_config.get_defaults()
+    enable_survey_report = click.confirm(
+        fmt.question(
+            "Would you like to send reports of usage back to the Open edX project?"
+            " Type 'n' if you don't want to"
+        ),
+        prompt_suffix=" ",
+        default=True,
+    )
+    config["SURVEYREPORT_ENABLE"] = enable_survey_report
+
+    if enable_survey_report:
+        ask_bool(
+            (
+                "Send anonymous survey report? Important note:"
+                " the report will be sent with a unique id instead of site name."
+            ),
+            "SURVEYREPORT_ANONYMOUS",
+            config,
+            defaults,
+        )
+        ask_bool(
+            (
+                "Send survey report automatically? Important note:"
+                " If you don't want to send it automatically, you must send it from Django admin."
+            ),
+            "SURVEYREPORT_AUTO_SEND",
+            config,
+            defaults,
+        )
+        

--- a/surveyreport/hooks.py
+++ b/surveyreport/hooks.py
@@ -15,8 +15,8 @@ def ask_survey_report_questions(config: Config) -> None:
     """The report data will be sent to Axim Collaborative, the non-profit behind the Open edX project."""
     )
 
-    texto_con_enlace = click.style("See more: https://github.com/eduNEXT/edx-platform/tree/master/openedx/features/survey_report#survey-report", fg='blue', underline=True)
-    click.echo(texto_con_enlace)
+    link_to_docs = click.style("See more: https://github.com/eduNEXT/edx-platform/tree/master/openedx/features/survey_report#survey-report", fg='blue', underline=True)
+    click.echo(link_to_docs)
 
     defaults = tutor_config.get_defaults()
     enable_survey_report = click.confirm(

--- a/surveyreport/hooks.py
+++ b/surveyreport/hooks.py
@@ -15,7 +15,7 @@ def ask_survey_report_questions(config: Config) -> None:
     """The report data will be sent to Axim Collaborative, the non-profit behind the Open edX project."""
     )
 
-    link_to_docs = click.style("See more: https://github.com/eduNEXT/edx-platform/tree/master/openedx/features/survey_report#survey-report", fg='blue', underline=True)
+    link_to_docs = click.style("See more: https://github.com/openedx/edx-platform/tree/master/openedx/features/survey_report#survey-report", fg='blue', underline=True)
     click.echo(link_to_docs)
 
     defaults = tutor_config.get_defaults()

--- a/surveyreport/plugin.py
+++ b/surveyreport/plugin.py
@@ -10,6 +10,8 @@ from tutor import hooks
 
 from .__about__ import __version__
 
+from surveyreport.hooks import *
+
 ########################################
 # CONFIGURATION
 ########################################

--- a/surveyreport/plugin.py
+++ b/surveyreport/plugin.py
@@ -22,10 +22,10 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # Each new setting is a pair: (setting_name, default_value).
         # Prefix your setting names with 'SURVEYREPORT_'.
         ("SURVEYREPORT_VERSION", __version__),
-        ("SURVEYREPORT_ENABLE", True),
+        ("SURVEYREPORT_ENABLE", False),
         ("SURVEYREPORT_SCHEDULE", "0 0 1 1,6 *"),
-        ("SURVEYREPORT_AUTO_SEND", True),
-        ("SURVEYREPORT_ANONYMOUS", False),
+        ("SURVEYREPORT_AUTO_SEND", False),
+        ("SURVEYREPORT_ANONYMOUS", True),
     ]
 )
 


### PR DESCRIPTION
## DESCRIPTION

This PR implement the CONFIG_INTERACTIVE action from tutor https://github.com/overhangio/tutor/pull/940 to add new interactive questions for survey report.

## MORE INFO

This PR is necessary to complete the implementation of the "Solubion B" https://openedx.atlassian.net/wiki/spaces/OEPM/pages/3872948238/Problem+Very+few+are+going+to+generate+and+send+the+Survey+Report.

## HOW TO TEST
- with a Tutor environment already created, install and enable the plugin.
- run the command `tutor local launch`